### PR TITLE
Rel wis cutoff

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -80,6 +80,7 @@ utils::globalVariables(c(
   "all_quantiles_present", # <use_ensemble_criteria>
   "horizon", # <use_ensemble_criteria>
   "designation", # <use_ensemble_criteria>
+  "rel_wis", # <use_ensemble_criteria>
   "all_quantiles_all_horizons", # <use_ensemble_criteria>
   "not_excluded_manually", # <use_ensemble_criteria>
   "included_in_ensemble", # <use_ensemble_criteria>

--- a/R/run_ensemble.R
+++ b/R/run_ensemble.R
@@ -70,8 +70,7 @@ run_ensemble <- function(method = "mean",
                                      exclude_models = exclude_models,
                                      return_criteria = return_criteria,
                                      exclude_designated_other = exclude_designated_other,
-                                     rel_wis_cutoff = rel_wis_cutoff,
-                                     ...)
+                                     rel_wis_cutoff = rel_wis_cutoff)
 
   if (return_criteria) {
     criteria <- forecasts$criteria

--- a/R/run_ensemble.R
+++ b/R/run_ensemble.R
@@ -29,6 +29,7 @@ run_ensemble <- function(method = "mean",
                          verbose = FALSE,
                          exclude_designated_other = TRUE,
                          identifier = "",
+                         rel_wis_cutoff = Inf,
                          ...) {
 
   # Method ------------------------------------------------------------------
@@ -69,6 +70,7 @@ run_ensemble <- function(method = "mean",
                                      exclude_models = exclude_models,
                                      return_criteria = return_criteria,
                                      exclude_designated_other = exclude_designated_other,
+                                     rel_wis_cutoff = rel_wis_cutoff,
                                      ...)
 
   if (return_criteria) {

--- a/R/use_ensemble_criteria.R
+++ b/R/use_ensemble_criteria.R
@@ -116,6 +116,10 @@ use_ensemble_criteria <- function(forecasts,
     select(model, target_variable, location) %>%
     mutate(included_in_ensemble = TRUE)
 
+  if (nrow(include) == 0) {
+    warning("No models left after applying inclusion criteria.")
+  }
+
   criteria <- left_join(criteria, include,
                         by = c("model", "target_variable", "location")) %>%
     mutate(included_in_ensemble = ifelse(is.na(included_in_ensemble),

--- a/R/use_ensemble_criteria.R
+++ b/R/use_ensemble_criteria.R
@@ -39,7 +39,8 @@ use_ensemble_criteria <- function(forecasts,
                                   exclude_models = NULL,
                                   exclude_designated_other = TRUE,
                                   return_criteria = TRUE,
-                                  eval_dir = here::here("evaluation", "weekly-summary")) {
+                                  eval_dir = here::here("evaluation", "weekly-summary"),
+                                  rel_wis_cutoff = Inf) {
 
   # Remove point forecasts
   forecasts <- filter(forecasts, type == "quantile")

--- a/R/use_ensemble_criteria.R
+++ b/R/use_ensemble_criteria.R
@@ -89,7 +89,7 @@ use_ensemble_criteria <- function(forecasts,
   # 6. Cut-off by relative WIS
   if (is.finite(rel_wis_cutoff)) {
     evaluation_date <- max(forecasts$forecast_date)
-    evaluation_file <- here("evaluation", paste0("evaluation-", evaluation_date, ".csv"))
+    evaluation_file <- file.path(eval_dir, paste0("evaluation-", evaluation_date, ".csv"))
     if (file.exists(evaluation_file)) {
       evaluation <- vroom(evaluation_file) %>%
         filter(!is.na(rel_wis)) %>%

--- a/man/run_ensemble.Rd
+++ b/man/run_ensemble.Rd
@@ -12,6 +12,7 @@ run_ensemble(
   verbose = FALSE,
   exclude_designated_other = TRUE,
   identifier = "",
+  rel_wis_cutoff = Inf,
   ...
 )
 }
@@ -34,6 +35,9 @@ be printed while running (defaults to \code{FALSE}).}
 as "other" in their metadata file (default \code{TRUE})}
 
 \item{identifier}{an identifier to prepend to each model name}
+
+\item{rel_wis_cutoff}{numeric: any model with relative WIS greater than this
+value will be excluded}
 
 \item{...}{arguments passed to \code{\link[=create_ensemble_relative_skill]{create_ensemble_relative_skill()}}}
 }

--- a/man/use_ensemble_criteria.Rd
+++ b/man/use_ensemble_criteria.Rd
@@ -9,7 +9,8 @@ use_ensemble_criteria(
   exclude_models = NULL,
   exclude_designated_other = TRUE,
   return_criteria = TRUE,
-  eval_dir = here::here("evaluation", "weekly-summary")
+  eval_dir = here::here("evaluation", "weekly-summary"),
+  rel_wis_cutoff = Inf
 )
 }
 \arguments{
@@ -27,6 +28,9 @@ as "other" in their metadata file (default \code{TRUE})}
 grid as well as the ensemble forecast (default \code{TRUE})}
 
 \item{eval_dir}{character: the path in which to look for evaluation csv files}
+
+\item{rel_wis_cutoff}{numeric: any model with relative WIS greater than this
+value will be excluded}
 }
 \value{
 \itemize{


### PR DESCRIPTION
Implements an optional cutoff by relative WIS when creating ensembles. Any model that has a relative WIS greater than the given value will be excluded. Default value is `Inf`, i.e. no models excluded by threshold.