### PR TITLE
option to specify minimum number of models

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -34,8 +34,9 @@ utils::globalVariables(c(
   "type", # <run_ensemble>
   "quantile", # <run_ensemble>
   "horizon", # <run_ensemble>
-  "target_variable", # <run_ensemble>
   "location", # <run_ensemble>
+  "temporal_resolution", # <run_ensemble>
+  "target_variable", # <run_ensemble>
   "weight", # <run_ensemble>
   "included_in_ensemble", # <run_ensemble>
   "location", # <score_forecasts>

--- a/R/run_ensemble.R
+++ b/R/run_ensemble.R
@@ -90,9 +90,7 @@ run_ensemble <- function(method = "mean",
     forecasts <- forecasts %>%
       group_by(forecast_date, location, horizon, temporal_resolution,
                target_variable) %>%
-      mutate(n = n_distinct(model)) %>%
-      filter(n >= min_nmodels) %>%
-      select(-n)
+      filter(n_distinct(model) >= min_nmodels)
   }
 
   # Run  ensembles ---------------------------------------------------

--- a/R/run_ensemble.R
+++ b/R/run_ensemble.R
@@ -86,12 +86,12 @@ run_ensemble <- function(method = "mean",
     mutate(quantile = round(quantile, 3),
            horizon = as.numeric(horizon))
 
-  if (min_nmodels > 0) {
-    forecasts <- forecasts %>%
-      group_by(forecast_date, location, horizon, temporal_resolution,
-               target_variable) %>%
-      filter(n_distinct(model) >= min_nmodels)
-  }
+  ## if min_nmodels is >0, this will ensure at least that many models
+  ## are included in the ensemble
+  forecasts <- forecasts %>%
+    group_by(forecast_date, location, horizon, temporal_resolution,
+             target_variable) %>%
+    filter(n_distinct(model) >= min_nmodels)
 
   # Run  ensembles ---------------------------------------------------
   # Averages

--- a/man/run_ensemble.Rd
+++ b/man/run_ensemble.Rd
@@ -8,6 +8,7 @@ run_ensemble(
   method = "mean",
   forecast_date,
   exclude_models = NULL,
+  min_nmodels = 0,
   return_criteria = TRUE,
   verbose = FALSE,
   exclude_designated_other = TRUE,
@@ -24,6 +25,8 @@ run_ensemble(
 \item{exclude_models}{optional character vector to exclude over all dates,
 or data.frame with cols model and forecast_date, to exclude for specific
 dates}
+
+\item{min_nmodels}{minimum number of models to create an ensemble}
 
 \item{return_criteria}{logical : whether to return a model/inclusion criteria
 grid as well as the ensemble forecast (default \code{TRUE})}


### PR DESCRIPTION
At the moment we're sometimes creating ensembles consisting of just 1 model, which is not great. This adds an option to specify the number of models.