### PR TITLE
fix grouping for counting models

### DIFF
--- a/R/run_ensemble.R
+++ b/R/run_ensemble.R
@@ -89,9 +89,11 @@ run_ensemble <- function(method = "mean",
   ## if min_nmodels is >0, this will ensure at least that many models
   ## are included in the ensemble
   forecasts <- forecasts %>%
-    group_by(forecast_date, location, horizon, temporal_resolution,
-             target_variable) %>%
-    filter(n_distinct(model) >= min_nmodels)
+    group_by(
+      location, horizon, temporal_resolution, target_variable, target_end_date
+    ) %>%
+    filter(n_distinct(model) >= min_nmodels) %>%
+    ungroup()
 
   # Run  ensembles ---------------------------------------------------
   # Averages


### PR DESCRIPTION
Fixes counting models for checking there are enough for the ensemble.

Previously this was done by `forecast_date` - but each submission has multiple forecast dates (not all teams submit on the same day) so this excluded forecasts that shouldn't be excluded. Now it is done by `horizon` and `target_end_date` which should be correct.