### PR TITLE
summarise_scores() - add arg to include mean score ratio

### DIFF
--- a/R/summarise_scores.R
+++ b/R/summarise_scores.R
@@ -5,6 +5,7 @@
 #' @param restrict_weeks Integer number of continuous weeks continuous weeks
 #' leading up to the `report_date` the forecasts need to include to be
 #' considered in the scoring.
+#' @param mean_scores_ratio return mean score ratio for each model against all other models, as well as relative WIS 
 #'
 #' @importFrom dplyr group_by mutate ungroup filter select bind_rows count summarise left_join select across n_distinct full_join distinct starts_with
 #' @importFrom tidyr complete replace_na


### PR DESCRIPTION
Adds new arg to include mean scores ratio in output.

If FALSE (default), output returns relative wis as currently with no changes. If TRUE, output includes rel wis and two new columns showing the mean score ratio from all models against all models ("mean_score_ratio" and "compare_against").

Example output without (mean_score_ratio = FALSE) and with (=TRUE) the new arg:

![image](https://user-images.githubusercontent.com/62290797/213318204-ff0620c7-1631-4ae8-bf26-7317669fd592.png)
